### PR TITLE
Updated and Added Tests

### DIFF
--- a/src/Exceptions/ModelClassCheckException.php
+++ b/src/Exceptions/ModelClassCheckException.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace EricDowell\ResourceController\Exceptions;
+
+use RuntimeException;
+
+class ModelClassCheckException extends RuntimeException
+{
+    /**
+     * Name of the affected Eloquent model.
+     *
+     * @var string
+     */
+    protected $model;
+
+    /**
+     * Set the affected Eloquent model.
+     *
+     * @param  string $model
+     * @return $this
+     */
+    public function setModel($model)
+    {
+        $this->model = $model;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isNull()
+    {
+        $this->message = 'Model property is empty.';
+
+        return is_null($this->model);
+    }
+
+    /**
+     * @return bool
+     */
+    public function classExists()
+    {
+        if ($this->isNull()) {
+            return false;
+        }
+        $this->message = "Model [{$this->model}] does not exist.";
+
+        return class_exists($this->model);
+    }
+}

--- a/src/Traits/WithModel.php
+++ b/src/Traits/WithModel.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Routing\Route as CurrentRoute;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use EricDowell\ResourceController\Exceptions\ModelClassCheckException;
 
 trait WithModel
 {
@@ -212,17 +212,17 @@ trait WithModel
     }
 
     /**
-     * @param string $model
+     * @param string|null $model
      *
      * @return $this
-     * @throws ModelNotFoundException
+     * @throws ModelClassCheckException
      */
-    protected function checkModelExists(string $model)
+    protected function checkModelExists(string $model = null)
     {
-        /** @var ModelNotFoundException $modelNotFound */
-        $modelNotFound = with(new ModelNotFoundException())->setModel($model);
-        if (! class_exists($modelNotFound->getModel())) {
-            throw $modelNotFound;
+        /** @var ModelClassCheckException $modelClassCheck */
+        $modelClassCheck = with(new ModelClassCheckException())->setModel($model);
+        if (! $modelClassCheck->classExists()) {
+            throw $modelClassCheck;
         }
 
         return $this;

--- a/tests/database/migrations/2018_04_19_021947_create_posts_test_table.php
+++ b/tests/database/migrations/2018_04_19_021947_create_posts_test_table.php
@@ -17,6 +17,7 @@ class CreatePostsTestTable extends Migration
             $table->bigIncrements('id');
             $table->string('title');
             $table->text('body');
+            $table->boolean('is_published')->default(false);
             $table->integer('user_id')->references('id')->on('users');
             $table->timestamps();
         });

--- a/tests/src/Feature/PostTest.php
+++ b/tests/src/Feature/PostTest.php
@@ -40,7 +40,7 @@ class PostTest extends TestCase
      *
      * @returns TestPost|null
      */
-    public function testModelStoreAndShow()
+    public function testModelStoreShowEdit()
     {
         /** @var Generator $faker */
         $faker = app(Generator::class);
@@ -50,9 +50,7 @@ class PostTest extends TestCase
 
         $authUser = factory(TestUser::class)->create();
         $response = $this->actingAs($authUser)->post(route('post.store'), compact('title', 'body'));
-
         $this->assertFunctionSuccess($response, __FILE__, __FUNCTION__, 302);
-
         $response->assertRedirect(url(route('post.index')));
 
         $model = TestPost::whereTitle($title)->first();
@@ -60,13 +58,14 @@ class PostTest extends TestCase
         $this->assertInstanceOf(TestPost::class, $model);
 
         $this->assertFunctionSuccess($this->get(route('post.show', $model->id)), __FILE__, __FUNCTION__);
+        $this->assertFunctionSuccess($this->get(route('post.edit', $model->id)), __FILE__, __FUNCTION__);
     }
 
     /**
      * @test
      * @group morph-model
      */
-    public function testModelUpdate()
+    public function testModelUpdateAndDestroy()
     {
         /** @var TestText $textPost */
         $textPost = factory(TestText::class, TestPost::class)->create();
@@ -79,14 +78,16 @@ class PostTest extends TestCase
 
         $authUser = factory(TestUser::class)->create();
         $response = $this->actingAs($authUser)->put(route('post.update', $textPost->id), compact('title', 'body'));
-
         $this->assertFunctionSuccess($response, __FILE__, __FUNCTION__, 302);
-
         $response->assertRedirect(url(route('post.index')));
 
         $textPost->refresh();
 
         $this->assertSame($title, $textPost->text->title);
         $this->assertSame($body, $textPost->text->body);
+
+        $response = $this->actingAs($authUser)->delete(route('post.destroy', $textPost->id));
+        $this->assertFunctionSuccess($response, __FILE__, __FUNCTION__, 302);
+        $response->assertRedirect(url(route('post.index')));
     }
 }

--- a/tests/src/Feature/PostTest.php
+++ b/tests/src/Feature/PostTest.php
@@ -17,6 +17,7 @@ class PostTest extends TestCase
 
     /**
      * @test
+     * @group feature
      * @group morph-model
      */
     public function testModelIndex()
@@ -26,6 +27,7 @@ class PostTest extends TestCase
 
     /**
      * @test
+     * @group feature
      * @group morph-model
      */
     public function testModelCreate()
@@ -36,6 +38,7 @@ class PostTest extends TestCase
 
     /**
      * @test
+     * @group feature
      * @group morph-model
      *
      * @returns TestPost|null
@@ -63,6 +66,7 @@ class PostTest extends TestCase
 
     /**
      * @test
+     * @group feature
      * @group morph-model
      */
     public function testModelUpdateAndDestroy()

--- a/tests/src/Feature/PostTest.php
+++ b/tests/src/Feature/PostTest.php
@@ -79,9 +79,10 @@ class PostTest extends TestCase
 
         $body = $faker->paragraph();
         $title = $faker->words(3, true);
+        $is_published = true;
 
         $authUser = factory(TestUser::class)->create();
-        $response = $this->actingAs($authUser)->put(route('post.update', $textPost->id), compact('title', 'body'));
+        $response = $this->actingAs($authUser)->put(route('post.update', $textPost->id), compact('title', 'body', 'is_published'));
         $this->assertFunctionSuccess($response, __FILE__, __FUNCTION__, 302);
         $response->assertRedirect(url(route('post.index')));
 
@@ -89,6 +90,7 @@ class PostTest extends TestCase
 
         $this->assertSame($title, $textPost->text->title);
         $this->assertSame($body, $textPost->text->body);
+        $this->assertTrue($textPost->text->is_published);
 
         $response = $this->actingAs($authUser)->delete(route('post.destroy', $textPost->id));
         $this->assertFunctionSuccess($response, __FILE__, __FUNCTION__, 302);

--- a/tests/src/Feature/UserTest.php
+++ b/tests/src/Feature/UserTest.php
@@ -15,6 +15,7 @@ class UserTest extends TestCase
 
     /**
      * @test
+     * @group feature
      * @group single-model
      */
     public function testModelIndex()
@@ -24,6 +25,7 @@ class UserTest extends TestCase
 
     /**
      * @test
+     * @group feature
      * @group single-model
      */
     public function testModelCreate()
@@ -34,6 +36,7 @@ class UserTest extends TestCase
 
     /**
      * @test
+     * @group feature
      * @group single-model
      *
      * @returns TestUser|null
@@ -65,6 +68,7 @@ class UserTest extends TestCase
 
     /**
      * @test
+     * @group feature
      * @group single-model
      */
     public function testModelUpdateAndDestroy()

--- a/tests/src/Feature/UserTest.php
+++ b/tests/src/Feature/UserTest.php
@@ -38,7 +38,7 @@ class UserTest extends TestCase
      *
      * @returns TestUser|null
      */
-    public function testModelStoreAndShow()
+    public function testModelStoreShowEdit()
     {
         $user = factory(TestUser::class)->create();
         /** @var Generator $faker */
@@ -49,7 +49,6 @@ class UserTest extends TestCase
         $password = 'secret';
 
         $response = $this->actingAs($user)->post(route('user.store'), compact('name', 'email', 'password'));
-
         $this->assertFunctionSuccess($response, __FILE__, __FUNCTION__, 302);
 
         $response->assertRedirect(url(route('user.index')));
@@ -61,13 +60,14 @@ class UserTest extends TestCase
         $this->assertInstanceOf(TestUser::class, $model);
 
         $this->assertFunctionSuccess($this->get(route('user.show', $model->id)), __FILE__, __FUNCTION__);
+        $this->assertFunctionSuccess($this->get(route('user.edit', $model->id)), __FILE__, __FUNCTION__);
     }
 
     /**
      * @test
      * @group single-model
      */
-    public function testModelUpdate()
+    public function testModelUpdateAndDestroy()
     {
         /** @var TestUser $user */
         $user = factory(TestUser::class)->create();
@@ -80,14 +80,16 @@ class UserTest extends TestCase
         $password = 'secret';
 
         $response = $this->actingAs($user)->put(route('user.update', $user->id), compact('name', 'email', 'password'));
-
         $this->assertFunctionSuccess($response, __FILE__, __FUNCTION__, 302);
-
         $response->assertRedirect(url(route('user.index')));
 
         $user->refresh();
 
         $this->assertSame($name, $user->name);
         $this->assertSame($email, $user->email);
+
+        $response = $this->actingAs($user)->delete(route('user.destroy', $user->id));
+        $this->assertFunctionSuccess($response, __FILE__, __FUNCTION__, 302);
+        $response->assertRedirect(url(route('user.index')));
     }
 }

--- a/tests/src/Models/TestPost.php
+++ b/tests/src/Models/TestPost.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Model;
  * @method static \Illuminate\Database\Eloquent\Builder|\EricDowell\ResourceController\Tests\Models\TestPost whereCreatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\EricDowell\ResourceController\Tests\Models\TestPost whereId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\EricDowell\ResourceController\Tests\Models\TestPost whereTitle($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|\EricDowell\ResourceController\Tests\Models\TestPost whereIsPublished($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\EricDowell\ResourceController\Tests\Models\TestPost whereUpdatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|\EricDowell\ResourceController\Tests\Models\TestPost whereUserId($value)
  */
@@ -32,6 +33,15 @@ class TestPost extends Model
     protected $table = 'posts';
 
     /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'is_published' => 'boolean',
+    ];
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var array
@@ -39,6 +49,7 @@ class TestPost extends Model
     protected $fillable = [
         'title',
         'body',
+        'is_published',
         'user_id',
     ];
 

--- a/tests/src/Unit/WithModelResourceTest.php
+++ b/tests/src/Unit/WithModelResourceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace EricDowell\ResourceController\Tests\Unit;
+
+use EricDowell\ResourceController\Tests\TestCase;
+use EricDowell\ResourceController\Tests\Models\TestUser;
+use EricDowell\ResourceController\Http\Controllers\ResourceModelController;
+
+class WithModelResourceTest extends TestCase
+{
+    /**
+     * @test
+     * @group unit
+     * @group model-resource-trait
+     */
+    public function testGenerateDefaultsReturnsEmpty()
+    {
+        $noRouteAvailable = app(NoRouteAvailable::class);
+
+        $this->assertEmpty($noRouteAvailable->getMergeData());
+    }
+
+    /**
+     * @test
+     * @group unit
+     * @group model-resource-trait
+     *
+     * @expectedException \EricDowell\ResourceController\Exceptions\ModelClassCheckException
+     * @expectedExceptionMessage Model property is empty.
+     */
+    public function testExceptionThrownClassPropertyEmpty()
+    {
+        app(NoModelClassProperty::class);
+    }
+
+    /**
+     * @test
+     * @group unit
+     * @group model-resource-trait
+     *
+     * @expectedException \EricDowell\ResourceController\Exceptions\ModelClassCheckException
+     * @expectedExceptionMessage Model [FakeRandomClassNameDoesNotExist] does not exist.
+     */
+    public function testExceptionThrowClassDoesNotExist()
+    {
+        app(NoModelClassDoesNotExist::class);
+    }
+}
+
+class NoModelClassDoesNotExist extends ResourceModelController
+{
+    /**
+     * @var string
+     */
+    protected $modelClass = 'FakeRandomClassNameDoesNotExist';
+}
+
+class NoModelClassProperty extends ResourceModelController
+{
+}
+
+class NoRouteAvailable extends ResourceModelController
+{
+    /**
+     * @var string
+     */
+    protected $modelClass = TestUser::class;
+
+    /**
+     * @return array
+     */
+    public function getMergeData()
+    {
+        return $this->mergeData;
+    }
+}

--- a/tests/src/error-html/.gitignore
+++ b/tests/src/error-html/.gitignore
@@ -1,2 +1,2 @@
-.gitignore
+*
 !.gitignore


### PR DESCRIPTION
- Added more tests where coverage was missing.
- Throwing custom error when the `modelClass` or `morphModelClass` is empty or either properties class doesn't exist.